### PR TITLE
fix: guard cart store persistence during ssr

### DIFF
--- a/apps/web/stores/cart-store.ts
+++ b/apps/web/stores/cart-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
+import { persist, createJSONStorage, type StateStorage } from "zustand/middleware";
 
 export type CartModifier = {
   name: string;
@@ -32,9 +32,15 @@ interface CartState {
   setSplitGuests: (count: number) => void;
 }
 
+const noopStorage: StateStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+};
+
 const storage =
   typeof window === "undefined"
-    ? undefined
+    ? createJSONStorage(() => noopStorage)
     : createJSONStorage(() => window.localStorage);
 
 export const useCartStore = create<CartState>()(

--- a/src/stores/cart-store.ts
+++ b/src/stores/cart-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
+import { persist, createJSONStorage, type StateStorage } from "zustand/middleware";
 
 export type CartModifier = {
   name: string;
@@ -32,9 +32,15 @@ interface CartState {
   setSplitGuests: (count: number) => void;
 }
 
+const noopStorage: StateStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+};
+
 const storage =
   typeof window === "undefined"
-    ? undefined
+    ? createJSONStorage(() => noopStorage)
     : createJSONStorage(() => window.localStorage);
 
 export const useCartStore = create<CartState>()(


### PR DESCRIPTION
## Summary
- add a no-op storage fallback for the cart store so SSR and tests do not reference `window.localStorage`
- apply the same guard in the Next.js cart store mirror under `apps/web`

## Testing
- npm run lint -- src/stores/cart-store.ts apps/web/stores/cart-store.ts *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e58a40d5cc832596f48d0e0d63de6c